### PR TITLE
Hotfix/#1 multibyte

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -14,21 +14,23 @@ func TestBuildString(t *testing.T) {
 	// 引数有りのときのテストケース
 	{
 		type TestData struct {
-			desc string // テストの目的、説明
-			args []string
-			exe  bool
-			w, h int
-			box  []string
+			desc        string // テストの目的、説明
+			args        []string
+			exe         bool
+			paletteSize int
+			w, h        int
+			box         []string
 		}
 		tds := []TestData{
-			{desc: "引数を1つ指定する", args: []string{"hello"}, w: 5, h: 1, box: []string{"hello"}},
-			{desc: "引数を2つ指定する", args: []string{"hello", "world"}, w: 11, h: 1, box: []string{"hello world"}},
-			{desc: "引数に改行文字を含む", args: []string{"hello\nworld2"}, w: 6, h: 2, box: []string{"hello", "world2"}},
-			{desc: "シェルのコマンドを実行する", args: []string{"echo", "hello"}, exe: true, w: 5, h: 2, box: []string{"hello", ""}},
-			// TODO {desc: "マルチバイト文字を含む", args: []string{"あいうえお"}, w: 5, h: 2, box: []string{"hello", "world"}},
+			{desc: "引数を1つ指定する", args: []string{"hello"}, paletteSize: 128, w: 5, h: 1, box: []string{"hello"}},
+			{desc: "引数を2つ指定する", args: []string{"hello", "world"}, paletteSize: 128, w: 11, h: 1, box: []string{"hello world"}},
+			{desc: "引数に改行文字を含む", args: []string{"hello\nworld2"}, paletteSize: 128, w: 6, h: 2, box: []string{"hello", "world2"}},
+			{desc: "シェルのコマンドを実行する", args: []string{"echo", "hello"}, paletteSize: 128, exe: true, w: 5, h: 2, box: []string{"hello", ""}},
+			{desc: "マルチバイト文字を含む", args: []string{"あいうえお"}, paletteSize: 128, w: 10, h: 1, box: []string{"BBDDFFHHJJ"}},
+			{desc: "シングルバイト・マルチバイト混在", args: []string{"aiueo\nあいうえお"}, paletteSize: 128, w: 10, h: 2, box: []string{"aiueo", "BBDDFFHHJJ"}},
 		}
 		for _, v := range tds {
-			w, h, box := buildString(v.args, v.exe)
+			w, h, box := buildString(v.args, v.exe, v.paletteSize)
 			if v.w == w && v.h == h && as.Equal(v.box, box) {
 				t.Log(fmt.Sprintf("[OK] %s:", v.desc))
 			} else {
@@ -44,17 +46,19 @@ func TestBuildString(t *testing.T) {
 	// 引数なし（標準入力）のときのテストケース
 	{
 		type TestData struct {
-			desc  string // テストの目的、説明
-			stdin string
-			exe   bool
-			w, h  int
-			box   []string
+			desc        string // テストの目的、説明
+			stdin       string
+			exe         bool
+			paletteSize int
+			w, h        int
+			box         []string
 		}
 		tds := []TestData{
-			{desc: "標準入力から改行を含まない文字列を受け取る", stdin: "hello", w: 5, h: 1, box: []string{"hello"}},
-			{desc: "標準入力から改行を含む文字列を受け取る", stdin: "hello\nworld2", w: 6, h: 2, box: []string{"hello", "world2"}},
-			{desc: "シェルのコマンドを実行する", stdin: "echo hello", exe: true, w: 5, h: 2, box: []string{"hello", ""}},
-			// TODO {desc: "マルチバイト文字を含む", stdin: "hello\nworld2", w: 6, h: 2, box: []string{"hello", "world2"}},
+			{desc: "標準入力から改行を含まない文字列を受け取る", stdin: "hello", paletteSize: 128, w: 5, h: 1, box: []string{"hello"}},
+			{desc: "標準入力から改行を含む文字列を受け取る", stdin: "hello\nworld2", paletteSize: 128, w: 6, h: 2, box: []string{"hello", "world2"}},
+			{desc: "シェルのコマンドを実行する", stdin: "echo hello", exe: true, paletteSize: 128, w: 5, h: 2, box: []string{"hello", ""}},
+			{desc: "マルチバイト文字を含む", stdin: "あいうえお", paletteSize: 128, w: 10, h: 1, box: []string{"BBDDFFHHJJ"}},
+			{desc: "シングルバイト・マルチバイト混在", stdin: "aiueo\nあいうえお", paletteSize: 128, w: 10, h: 2, box: []string{"aiueo", "BBDDFFHHJJ"}},
 		}
 		for _, v := range tds {
 			// 標準入力にテキストを渡す
@@ -63,7 +67,7 @@ func TestBuildString(t *testing.T) {
 			stdinWrite.Close()
 			os.Stdin = stdinRead
 
-			w, h, box := buildString([]string{}, v.exe)
+			w, h, box := buildString([]string{}, v.exe, v.paletteSize)
 			if v.w == w && v.h == h && as.Equal(v.box, box) {
 				t.Log(fmt.Sprintf("[OK] %s:", v.desc))
 			} else {
@@ -74,5 +78,24 @@ func TestBuildString(t *testing.T) {
 				t.Error(fmt.Sprintf("[NG] %s:\n%s", v.desc, errMsg))
 			}
 		}
+	}
+}
+
+func TestFixValueThatOverBoundary(t *testing.T) {
+	as := assert.New(t)
+
+	type TestData struct {
+		desc     string // テストの目的、説明
+		s        string
+		boundary int
+		expect   string
+	}
+	tds := []TestData{
+		{desc: "アルファベットのみ", s: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", boundary: 128, expect: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"},
+		{desc: "全角のみ", s: "あいうえお", boundary: 128, expect: "BBDDFFHHJJ"},
+	}
+	for _, v := range tds {
+		got := fixValueThatOverBoundary(v.s, v.boundary)
+		as.Equal(v.expect, got, v.desc)
 	}
 }

--- a/palette/palette.go
+++ b/palette/palette.go
@@ -36,6 +36,11 @@ func NewPalette(path string) Palette {
 	}
 }
 
+// getColorTable は色パレット画像からカラーテーブルを作って返す。
+// 画像ファイルのパスに空文字列を指定すると組み込みの画像データから
+// カラーテーブルを作って返す。
+//
+// なお、このカラーテーブルを作るのに使用可能な画像フォーマットはPNGのみである。
 func getColorTable(path string) []color.Color {
 	var r io.Reader
 	if len(path) == 0 {
@@ -108,4 +113,8 @@ func (p Palette) Create(w, h int, src []string) *image.RGBA {
 	}
 
 	return rt
+}
+
+func (p Palette) GetPaletteSize() int {
+	return len(p.table)
 }


### PR DESCRIPTION
入力文字列にマルチバイト文字が存在したときにクラッシュする不具合を修正しました。
画像のパレットサイズを超過する文字が存在したら余りに変換するという内容になります。
ご確認のほどよろしくお願いいたします。
